### PR TITLE
feedback custom, fix #92 

### DIFF
--- a/book.json
+++ b/book.json
@@ -2,7 +2,7 @@
     "plugins": [
         "-lunr",
         "-search",
-        "github-issue-feedback-language",
+        "github-issue-feedback-language-custom",
         "search-title",
         "anchorjs",
         "toggle-chapters",
@@ -13,7 +13,7 @@
         "website": "./styles/website.css"
     },
     "pluginsConfig": {
-        "github-issue-feedback-language": {
+        "github-issue-feedback-language-custom": {
             "repo": "cocos2d/cocos2d-x-docs",
             "branch": "master"
         },


### PR DESCRIPTION
add disable feedback button support on smartphone
change button content to "提交反馈", when reading Chinese books

this is [the plugin code](https://github.com/drelaptop/gitbook-plugin-github-issue-feedback/blob/master/src/plugin.js#L48)

fix #92 #68 