### PR TITLE
修正网址链接错误。

### DIFF
--- a/zh/about/help.md
+++ b/zh/about/help.md
@@ -2,7 +2,7 @@
 
 在 Cocos2d-x 的使用过程中，您可以通过下面的方式获取帮助：
 
-- [Cocos 中文社区](//forum.cocos.com/)
+- [Cocos 中文社区](https://forum.cocos.com/)
 - [Cocos2d-x GitHub](https://github.com/cocos2d/cocos2d-x)
 - [API 编程接口](https://docs.cocos2d-x.org/api-ref/index.html)
 - [Cocos引擎官方微博](http://t.sina.com.cn/cocos2dx)

--- a/zh/about/learn.md
+++ b/zh/about/learn.md
@@ -5,7 +5,7 @@
 本文档就是最好的入门学习资源，其它一些有用的资源如下：
 
 - [Cocos官网](//www.cocos.com/)
-- [中文社区](//forum.cocos.com/)
+- [中文社区](https://forum.cocos.com)
 - [引擎官方测试项目](https://github.com/cocos2d/cocos2d-x/tree/v3/tests)
 
 > _测试项目的编译和运行在 [环境搭建章节](../installation/index.md) 介绍_

--- a/zh/about/learn.md
+++ b/zh/about/learn.md
@@ -4,7 +4,7 @@
 
 本文档就是最好的入门学习资源，其它一些有用的资源如下：
 
-- [Cocos官网](//www.cocos.com/)
+- [Cocos官网](https://www.cocos.com/)
 - [中文社区](https://forum.cocos.com)
 - [引擎官方测试项目](https://github.com/cocos2d/cocos2d-x/tree/v3/tests)
 


### PR DESCRIPTION
点击了解引官网网址和中文社区网址没有反应，右键新的标签页打开是404界面。
把网址修改为正确的网址。
在之前的网址之前加上了https:。