### PR TITLE
Fix the installation guide for MacOS

### DIFF
--- a/en/installation/OSX.md
+++ b/en/installation/OSX.md
@@ -25,9 +25,9 @@ cd <to where you want to clone this repo>
 
 git clone git@github.com:cocos2d/cocos2d-x.git
 
-git submodule update --init
+cd cocos2d-x
 
-git submodule update
+git submodule update --init
 
 ./download-deps.py
 ```


### PR DESCRIPTION
The installation guide misses the `cd cocos2d-x` command. Without that, the rest of the commands won't work.

In addition, `git submodule update` is covered by `git submodule update --init`, so this command can be omitted.